### PR TITLE
feat(shield): add modular Shield silentCAPTCHA integration with globall + per-form controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ docs/BACKGROUND-PROCESSING.md
 docs/TESTING-GUIDE.md
 includes/functions.php.backup_20251222_221754
 .gitignore
+/.idea

--- a/includes/admin/assets/js/admin-efb.js
+++ b/includes/admin/assets/js/admin-efb.js
@@ -1749,6 +1749,13 @@ let change_el_edit_Efb = (el) => {
           el.classList.remove('active');
        }
         break;
+      case "shieldSilentCaptchaEl":
+        const shieldAvailable = efb_var.shield_available === true || efb_var.shield_available === 1 || efb_var.shield_available === '1' || efb_var.shield_available === 'true';
+        if (!shieldAvailable) {
+          return;
+        }
+        valj_efb[0].shield_silent_captcha = el.classList.contains('active') == true ? true : false;
+        break;
       case "showSIconsEl":
         valj_efb[0].show_icon =  el.classList.contains('active')==true ? true : false
         break;

--- a/includes/admin/assets/js/list_form-efb.js
+++ b/includes/admin/assets/js/list_form-efb.js
@@ -1205,6 +1205,8 @@ function fun_show_setting__emsFormBuilder() {
   let femail ='null';
   let demail ='no-reply@'+ window.location.hostname;
   let osLocationPicker = false;
+  let shieldSilentCaptcha = false;
+  const shieldAvailable = efb_var.shield_available === true || efb_var.shield_available === 1 || efb_var.shield_available === '1' || efb_var.shield_available === 'true';
   const translateDiscountPercent = 60;
   // Response box color settings (defaults)
   let respPrimary = '#3644d2';
@@ -1261,6 +1263,8 @@ function fun_show_setting__emsFormBuilder() {
     phoneNumbers = f('phnNo');
     adminSN  = f('adminSN') =='null' ? true :f('adminSN');
     sessionDuration = f('sessionDuration') == 'null' ? 1 : parseInt(f('sessionDuration'));
+    const shieldSilentCaptchaSetting = f('shield_silent_captcha');
+    shieldSilentCaptcha = shieldSilentCaptchaSetting === true || shieldSilentCaptchaSetting === 1 || shieldSilentCaptchaSetting === '1' || shieldSilentCaptchaSetting === 'true';
 
     // Load response box color settings
     respPrimary = f('respPrimary') == 'null' ? '#3644d2' : f('respPrimary');
@@ -1567,6 +1571,19 @@ function fun_show_setting__emsFormBuilder() {
                                 <label class="efb  form-label mx-2 col-12  mt-4 fs-6">${efb_var.text.SecreTKey}</label>
                                 <input type="text" class="efb form-control w-75 h-d-efb border-d efb-rounded ${Number(efb_var.rtl) == 1 ? 'rtl-text' : ''}" id="secretkey_emsFormBuilder" placeholder="${efb_var.text.SecreTKey}" ${secretkey !== "null" ? `value="${secretkey}"` : ""} data-tab="${efb_var.text.googleKeys}">
                                 <span id="secretkey_emsFormBuilder-message" class="efb text-danger col-12 efb"></span>
+                            </div>
+
+                            <h5 class="efb  card-title mt-3 mobile-title">
+                                <i class="efb bi-shield-check m-3"></i>${efb_var.text.shieldSilentCaptcha}
+                            </h5>
+                            <p class="efb ${mxCSize}">${efb_var.text.shieldSilentCaptchaDesc}</p>
+                            <p class="efb ${mxCSize}"><a target="_blank" href="https://clk.shldscrty.com/silentcaptchaintegrationhelp">${efb_var.text.lmavt.replace('%s','Shield silentCAPTCHA')}</a></p>
+                            ${shieldAvailable ? '' : `<p class="efb ${mxCSize} text-warning">${efb_var.text.shieldNotDetected}</p>`}
+                            <div class="efb card-body mx-0 py-1 ${mxCSize4}">
+                                <button type="button" id="shieldSilentCaptcha_emsFormBuilder" data-state="off" data-name="disabled" class="efb mx-0 btn h-s-efb  btn-toggle  ${shieldSilentCaptcha == true ? "active" : ""}" data-toggle="button" aria-pressed="false" autocomplete="off" ${shieldAvailable ? '' : 'disabled aria-disabled="true"'}>
+                                <div class="efb handle"></div>
+                                </button>
+                                <label class="efb form-check-label fs-6 efb mx-2 my-3" for="shieldSilentCaptcha_emsFormBuilder">${efb_var.text.shieldSilentCaptcha}</label>
                             </div>
 
                             <h5 class="efb  card-title mt-3 mobile-title d-none">
@@ -2454,6 +2471,7 @@ function fun_set_setting_emsFormBuilder(state_auto = 0) {
    // const bootstrap = f('bootstrap_emsFormBuilder');
     const osLocationPicker = f('osLocationPicker_emsFormBuilder');
     const scaptcha = f('scaptcha_emsFormBuilder');
+    const shieldSilentCaptcha = f('shieldSilentCaptcha_emsFormBuilder');
 
     const activeDlBtn = f('activeDlBtn_emsFormBuilder');
     const showUpfile = f('showUpfile_emsFormBuilder');
@@ -2554,7 +2572,7 @@ function fun_set_setting_emsFormBuilder(state_auto = 0) {
          apiKeyMap: `${apiKeyMap}`, smtp: smtp, text: text, bootstrap, emailTemp: emailTemp,
          paypalPKey: paypalPKey, paypalSKey: paypalSKey,
          stripePKey: stripePKey, stripeSKey: stripeSKey, payToken: payToken, act_local_efb:act_local_efb,
-          scaptcha:scaptcha ,activeDlBtn:activeDlBtn,dsupfile:showUpfile,sms_config:sms_config_efb,
+          scaptcha:scaptcha ,shield_silent_captcha:shieldSilentCaptcha,activeDlBtn:activeDlBtn,dsupfile:showUpfile,sms_config:sms_config_efb,
          AdnSPF:AdnSPF,AdnOF:AdnOF,AdnPPF:AdnPPF,AdnATC:AdnATC,AdnSS:AdnSS,AdnCPF:AdnCPF,AdnESZ:AdnESZ,
          AdnSE:AdnSE,AdnWHS:AdnWHS, AdnPAP:AdnPAP, AdnWSP:AdnWSP,AdnSMF:AdnSMF,AdnPLF:AdnPLF,AdnMSF:AdnMSF,
          AdnBEF:AdnBEF,AdnPDP:AdnPDP,AdnADP:AdnADP,phnNo:phoneNumbers , femail:femail,email_key:email_key_efb,showIp:showIp,adminSN:adminSN,osLocationPicker:osLocationPicker,sessionDuration:sessionDuration,

--- a/includes/admin/assets/js/val-efb.js
+++ b/includes/admin/assets/js/val-efb.js
@@ -744,6 +744,19 @@ function show_setting_window_efb(idset) {
     </button>
     <label class="efb form-check-label" for="captchaEl">${efb_var.text.addGooglereCAPTCHAtoForm}</label>
     </div>`;
+    const stateTrueEfb = (value) => value === true || value === 1 || value === '1' || value === 'true';
+    const shieldAvailable = stateTrueEfb(efb_var.shield_available);
+    const shieldGlobalEnabled = efb_var.hasOwnProperty('setting') && efb_var.setting != null ? stateTrueEfb(efb_var.setting.shield_silent_captcha) : false;
+    const shieldOverrideExists = valj_efb[indx].hasOwnProperty('shield_silent_captcha');
+    const shieldOverrideEnabled = stateTrueEfb(valj_efb[indx].shield_silent_captcha);
+    const shieldSilentCaptchaActive = shieldOverrideExists ? shieldOverrideEnabled : shieldGlobalEnabled;
+    const shieldSilentCaptchaEls = `<div class="efb mx-1 my-3 efb">
+    <button type="button" id="shieldSilentCaptchaEl" data-state="off" data-name="disabled" class="efb mx-0 btn h-s-efb  btn-toggle ${shieldSilentCaptchaActive ? 'active' : ''}" data-toggle="button" aria-pressed="false" autocomplete="off" data-id="${idset}" onclick="fun_switch_form_efb(this)" ${shieldAvailable ? '' : 'disabled aria-disabled="true"'}>
+    <div class="efb handle"></div>
+    </button>
+    <label class="efb form-check-label" for="shieldSilentCaptchaEl">${efb_var.text.shieldSilentCaptcha}</label>
+    ${shieldAvailable ? '' : `<p class="efb fs-7 mt-1 mb-0 text-warning">${efb_var.text.shieldNotDetected}</p>`}
+    </div>`;
     const showSIconsEls = `<div class="efb mx-1 my-3 efb">
     <button type="button" id="showSIconsEl" data-state="off" data-name="disabled" class="efb mx-0 btn h-s-efb  btn-toggle ${valj_efb[indx].hasOwnProperty('show_icon') && Number(valj_efb[indx].show_icon) == 1 ? 'active' : ''}" data-toggle="button" aria-pressed="false" autocomplete="off"  data-id="${idset}"  onclick="fun_switch_form_efb(this)" >
     <div class="efb handle"></div>
@@ -1742,9 +1755,10 @@ function show_setting_window_efb(idset) {
         deactive_element_efb();
         body = `
           <label for="formNameEl" class="efb form-label mt-2 mb-1 efb">${efb_var.text.formName}<span class="efb  mx-1 efb text-danger">*</span></label>
-           <input type="text"  data-id="${idset}" class="efb elEdit text-muted form-control efb  h-d-efb  mb-1"  placeholder="${efb_var.text.formName}" id="formNameEl" required value="${valj_efb[0].formName}">
+          <input type="text"  data-id="${idset}" class="efb elEdit text-muted form-control efb  h-d-efb  mb-1"  placeholder="${efb_var.text.formName}" id="formNameEl" required value="${valj_efb[0].formName}">
           ${trackingCodeEls}
           ${captchaEls}
+          ${shieldSilentCaptchaEls}
           ${showSIconsEls}
           ${showSprosiEls}
           ${showformLoggedEls}

--- a/includes/admin/class-Emsfb-addon.php
+++ b/includes/admin/class-Emsfb-addon.php
@@ -153,7 +153,7 @@ class Addon {
 			if($ac->smtp=="true"){$smtp=1;}else if ($ac->smtp=="false"){$smtp=0;$smtp_m =$lang['sMTPNotWork'];}
 		}else{$smtp_m =$lang['goToEFBAddEmailM'];}
 		wp_enqueue_script( 'Emsfb-admin-js', EMSFB_PLUGIN_URL . 'includes/admin/assets/js/admin-efb.js',false,EMSFB_PLUGIN_VERSION);
-		wp_localize_script('Emsfb-admin-js','efb_var',array(
+		$efb_var_data = apply_filters('efb_admin_localize_vars', array(
 			'ajax_url' => admin_url('admin-ajax.php'),
 			'nonce'=> wp_create_nonce("wp_rest"),
 			'check' => 2,
@@ -171,7 +171,8 @@ class Addon {
 			'wp_lan'=>get_locale(),
 			'v_efb'=>EMSFB_PLUGIN_VERSION,
 			'setting'=>$ac,
-		));
+		), 'addon');
+		wp_localize_script('Emsfb-admin-js','efb_var',$efb_var_data);
 		wp_enqueue_script('efb-val-js', EMSFB_PLUGIN_URL . 'includes/admin/assets/js/val-efb.js',false,EMSFB_PLUGIN_VERSION);
 		 wp_enqueue_script( 'Emsfb-core-js', EMSFB_PLUGIN_URL . 'includes/admin/assets/js/core-efb.js',false,EMSFB_PLUGIN_VERSION);
 		 wp_localize_script('Emsfb-core-js','ajax_object_efm_core',array(

--- a/includes/admin/class-Emsfb-create.php
+++ b/includes/admin/class-Emsfb-create.php
@@ -237,7 +237,7 @@ class Create {
 		$plugins['cache'] =$efbFunction->check_for_active_plugins_cache();
 		$location ='';
 		wp_enqueue_script( 'Emsfb-admin-js', EMSFB_PLUGIN_URL . 'includes/admin/assets/js/admin-efb.js',false,EMSFB_PLUGIN_VERSION);
-		wp_localize_script('Emsfb-admin-js','efb_var',array(
+		$efb_var_data = apply_filters('efb_admin_localize_vars', array(
 			'ajax_url' => admin_url('admin-ajax.php'),
 			'nonce'=> wp_create_nonce("wp_rest"),
 			'check' => 1,
@@ -259,7 +259,8 @@ class Create {
 			'colors'=>$colors,
 			'zone_area'=>CDN_ZONE_AREA,
 			'plugins'=>$plugins
-		));
+		), 'create');
+		wp_localize_script('Emsfb-admin-js','efb_var',$efb_var_data);
 		wp_enqueue_script('efb-val-js', EMSFB_PLUGIN_URL . 'includes/admin/assets/js/val-efb.js',false,EMSFB_PLUGIN_VERSION);
 		wp_enqueue_script('efb-pro-els', EMSFB_PLUGIN_URL . 'includes/admin/assets/js/pro_els-efb.js',false,EMSFB_PLUGIN_VERSION);
 		wp_enqueue_script('efb-forms-js', EMSFB_PLUGIN_URL . 'includes/admin/assets/js/forms-efb.js',false,EMSFB_PLUGIN_VERSION);

--- a/includes/admin/class-Emsfb-panel.php
+++ b/includes/admin/class-Emsfb-panel.php
@@ -218,7 +218,7 @@ class Panel_edit  {
 			$sid = $efbFunction->efb_code_validate_create(0, 1, 'admin' , 0);
 			$plugins['cache'] = $efbFunction->check_for_active_plugins_cache();
 			wp_enqueue_script( 'Emsfb-admin-js', EMSFB_PLUGIN_URL . 'includes/admin/assets/js/admin-efb.js',false,EMSFB_PLUGIN_VERSION);
-			wp_localize_script('Emsfb-admin-js','efb_var',array(
+			$efb_var_data = apply_filters('efb_admin_localize_vars', array(
 				'ajax_url' => admin_url('admin-ajax.php'),
 				'nonce'=> wp_create_nonce("wp_rest"),
 				'pro' => $pro ? 1 : 0,
@@ -241,7 +241,8 @@ class Panel_edit  {
 				'rest_url'=>get_rest_url(null),
 				'plugins'=>$plugins,
 				'wsteam'=> $wsteam_domain,
-			));
+			), 'panel');
+			wp_localize_script('Emsfb-admin-js','efb_var',$efb_var_data);
 			wp_enqueue_script('efb-val-js', EMSFB_PLUGIN_URL . 'includes/admin/assets/js/val-efb.js',false,EMSFB_PLUGIN_VERSION);
 			wp_enqueue_script('efb-pro-els', EMSFB_PLUGIN_URL . 'includes/admin/assets/js/pro_els-efb.js',false,EMSFB_PLUGIN_VERSION);
 			$lng_ = get_locale();

--- a/includes/class-Emsfb-public.php
+++ b/includes/class-Emsfb-public.php
@@ -1852,7 +1852,7 @@ public function check_nonce_permission_efb($request) {
 
 		$text_ = [
 			'somethingWentWrongPleaseRefresh', 'pleaseMakeSureAllFields', 'bkXpM', 'bkFlM', 'mnvvXXX', 'ptrnMmm', 'ptrnMmx', 'payment', 'error403', 'errorSiteKeyM',
-			'errorCaptcha', 'pleaseEnterVaildValue', 'createAcountDoneM', 'incorrectUP', 'sentBy', 'newPassM', 'done', 'surveyComplatedM', 'error405', 'errorSettingNFound',
+			'errorCaptcha', 'pleaseEnterVaildValue', 'createAcountDoneM', 'incorrectUP', 'sentBy', 'newPassM', 'done', 'surveyComplatedM', 'error405', 'errorSettingNFound', 'errorMRobot',
 			'clcdetls', 'vmgs', 'youRecivedNewMessage', 'WeRecivedUrM', 'thankRegistering', 'welcome', 'thankSubscribing', 'thankDonePoll', 'thankFillForm', 'trackNo', 'fernvtf', 'msgdml', 'newMessageReceived','sxnlex','snotfound','response','fform','msgSndBut','smsWPN',
 			'surveyResults', 'responses'
 		];
@@ -2640,6 +2640,17 @@ public function check_nonce_permission_efb($request) {
 						wp_send_json_success($response, 200);
 						return;
 					}
+				}
+				$shield_should_block = apply_filters('efb_submit_bot_decision', false, [
+					'setting' => is_array($setting) ? $setting : [],
+					'form' => (is_array($formObj) && isset($formObj[0]) && is_array($formObj[0])) ? $formObj[0] : [],
+					'ip' => $this->get_ip_address(),
+					'efbFunction' => $this->efbFunction,
+				]);
+				if ($shield_should_block === true) {
+					$response = ['success' => false, 'm' => $this->lanText['errorMRobot']];
+					wp_send_json_success($response, 200);
+					return;
 				}
 				// error_log('after captcha: ' . $type);
 				if ($type == "logout" || $type == "recovery") {

--- a/includes/class-Emsfb.php
+++ b/includes/class-Emsfb.php
@@ -114,10 +114,12 @@ class Emsfb {
             // Check if EMSFB_PLUGIN_DIRECTORY . '/vendor/autofill/class-Emsfb-autofill.php' exists
 
 
-        }
+		}
 
+		require_once $this->plugin_path . 'includes/integrations/class-Emsfb-shield-silentcaptcha.php';
+		new Emsfb_Shield_SilentCaptcha_Integration();
 
-        require_once $this->plugin_path . 'includes/class-Emsfb-public.php';
+		require_once $this->plugin_path . 'includes/class-Emsfb-public.php';
        // require_once $this->plugin_path . 'includes/class-Emsfb-webhook.php';
 
        // Load page builder integrations (available for both admin and frontend)

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -572,6 +572,9 @@ class efbFunction {
 			"whenEasyFormBuilderRecivesNewMessage" => $state ? $ac->text->whenEasyFormBuilderRecivesNewMessage : esc_html__('When a new message is received through an Easy Form Builder forms, an alert email is sent to the site administrator.','easy-form-builder'),
 			/* translators: reCAPTCHA v2 = Google's version 2 anti-spam verification system */
 			"reCAPTCHAv2" => $state ? $ac->text->reCAPTCHAv2 : esc_html__('reCAPTCHA v2','easy-form-builder'),
+			"shieldSilentCaptcha" => $state && isset($ac->text->shieldSilentCaptcha) ? $ac->text->shieldSilentCaptcha : esc_html__('Add Shield silentCAPTCHA Bot SPAM Protection','easy-form-builder'),
+			"shieldSilentCaptchaDesc" => $state && isset($ac->text->shieldSilentCaptchaDesc) ? $ac->text->shieldSilentCaptchaDesc : esc_html__("Use Shield Security's silentCAPTCHA protection against bot spam form submissions.",'easy-form-builder'),
+			"shieldNotDetected" => $state && isset($ac->text->shieldNotDetected) ? $ac->text->shieldNotDetected : esc_html__('Shield Security is not detected. Install and activate it to use this setting.','easy-form-builder'),
 			"clickHereWatchVideoTutorial" => $state ? $ac->text->clickHereWatchVideoTutorial : esc_html__('Click here to watch a video tutorial.','easy-form-builder'),
 			"siteKey" => $state ? $ac->text->siteKey : esc_html__('Site Key','easy-form-builder'),
 			"SecreTKey" => $state ? $ac->text->SecreTKey : esc_html__('Secret Key','easy-form-builder'),

--- a/includes/integrations/class-Emsfb-shield-silentcaptcha.php
+++ b/includes/integrations/class-Emsfb-shield-silentcaptcha.php
@@ -1,0 +1,80 @@
+<?php
+
+if (!defined('ABSPATH')) {
+	die("Direct access of plugin files is not allowed.");
+}
+
+class Emsfb_Shield_SilentCaptcha_Integration {
+	public const SETTING_KEY = 'shield_silent_captcha';
+	public const FORM_KEY = 'shield_silent_captcha';
+
+	public function __construct() {
+		add_filter('efb_admin_localize_vars', [$this, 'filter_admin_localize_vars'], 10, 2);
+		add_filter('efb_submit_bot_decision', [$this, 'filter_submit_bot_decision'], 10, 2);
+	}
+
+	public function filter_admin_localize_vars($vars, $context = '') {
+		if (!is_array($vars)) {
+			return $vars;
+		}
+		$vars['shield_available'] = $this->is_shield_available_efb();
+		return $vars;
+	}
+
+	public function filter_submit_bot_decision($should_block, $context = array()) {
+		if ($should_block === true) {
+			return true;
+		}
+		if (!is_array($context)) {
+			return false;
+		}
+
+		$setting = isset($context['setting']) && is_array($context['setting']) ? $context['setting'] : [];
+		$form = isset($context['form']) && is_array($context['form']) ? $context['form'] : [];
+		$shield_enabled = isset($setting[self::SETTING_KEY]) && $this->is_true_state_efb($setting[self::SETTING_KEY]);
+		if (array_key_exists(self::FORM_KEY, $form)) {
+			$shield_enabled = $this->is_true_state_efb($form[self::FORM_KEY]);
+		}
+		if (!$shield_enabled) {
+			return false;
+		}
+
+		$ip = isset($context['ip']) ? sanitize_text_field((string) $context['ip']) : '';
+		if ($ip === '') {
+			return false;
+		}
+
+		return $this->get_shield_bot_verdict_efb($ip) === true;
+	}
+
+	private function is_true_state_efb($value): bool {
+		return in_array($value, [true, 1, '1', 'true'], true);
+	}
+
+	private function is_shield_available_efb(): bool {
+		return is_callable('\FernleafSystems\Wordpress\Plugin\Shield\Functions\test_ip_is_bot')
+			|| is_callable('shield_test_ip_is_bot');
+	}
+
+	private function get_shield_bot_verdict_efb(string $ip): ?bool {
+		try {
+			if (is_callable('\FernleafSystems\Wordpress\Plugin\Shield\Functions\test_ip_is_bot')) {
+				$result = \FernleafSystems\Wordpress\Plugin\Shield\Functions\test_ip_is_bot($ip);
+			} elseif (is_callable('shield_test_ip_is_bot')) {
+				$result = shield_test_ip_is_bot($ip);
+			} else {
+				return null;
+			}
+		} catch (\Throwable $e) {
+			return null;
+		}
+
+		if ($result === true) {
+			return true;
+		}
+		if ($result === false) {
+			return false;
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
This change adds Shield silentCAPTCHA to Easy Form Builder in a modular way, with graceful fallback when Shield is not installed.

The goal was to make the integration feel native to the plugin while keeping the footprint small and easy to remove.

Why this structure
- Keep Shield-specific logic out of core flows as much as possible.
- Reuse existing plugin patterns for settings, localization, and form-level overrides.
- Preserve current reCAPTCHA behavior and response contracts.
- Fail open when Shield is unavailable, errors, or returns an unknown result.

How it is wired
1) Dedicated integration class
- Added `includes/integrations/class-Emsfb-shield-silentcaptcha.php`
- Loaded from `includes/class-Emsfb.php`
- This class is the main entry point for Shield behavior.

2) New extension hooks
- `efb_admin_localize_vars`
  - Added as a filter around existing `efb_var` localization payloads.
  - Applied in:
    - `includes/admin/class-Emsfb-create.php`
    - `includes/admin/class-Emsfb-panel.php`
    - `includes/admin/class-Emsfb-addon.php`
  - Purpose:
    - Allow integrations to add admin-localized data without duplicating logic in each admin class.
    - Shield uses this to inject `shield_available`.

- `efb_submit_bot_decision`
  - Called from submit flow in `includes/class-Emsfb-public.php` (forms/message/add).
  - Purpose:
    - Let integration code decide whether a request should be blocked as bot traffic.
    - Keep submit flow generic and integration-agnostic.
  - Context passed:
    - global setting array
    - current form settings
    - client IP
    - current efbFunction instance

3) Settings and UI integration
- Global setting key: `shield_silent_captcha`
- Added global Shield toggle in settings modal:
  - `includes/admin/assets/js/list_form-efb.js`
- Added per-form override toggle in form settings:
  - `includes/admin/assets/js/val-efb.js`
  - `includes/admin/assets/js/admin-efb.js`
- Added Shield help link in the same style as reCAPTCHA help.
- When Shield is unavailable:
  - toggle is disabled
  - availability note is shown
  - saved value is not force-reset

4) Runtime behavior
- Submit endpoint integration is limited to `forms/message/add`.
- Shield block happens only when verdict is strict `true`.
- Missing Shield / exception / unknown verdict => continue submit (fail-open).
- Existing reCAPTCHA path remains unchanged.

5) Localization and naming
- Added text keys in `includes/functions.php`:
  - `shieldSilentCaptcha`
  - `shieldSilentCaptchaDesc`
  - `shieldNotDetected`
- Standardized key/ID naming to `silentCAPTCHA` format:
  - `shield_silent_captcha`
  - `shieldSilentCaptcha*`
- Included `errorMRobot` in submit handler text subset so Shield block message resolves correctly.

Scope and safety
- No DB schema changes.
- No REST contract changes.
- No tracker/reply anti-bot scope expansion.
- Integration remains removable by removing the integration class wiring/hooks.